### PR TITLE
Fix image preview classes in blog page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -103,7 +103,7 @@
                     <div class="col-md-12">
                         <article class="blog-post">
                             <a href="Post16.html">
-                                <img src="assets/img/blogpics/blog16/blog16.1.jpg" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/blog16/blog16.1.jpg" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -128,7 +128,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="Post15.html">
-                                <img src="assets/img/blogpics/Post15/15.1.jpg" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/Post15/15.1.jpg" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -154,7 +154,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="Post14.html">
-                                <img src="assets/img/blogpics/blog 14/14.1.jpg" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/blog 14/14.1.jpg" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -180,7 +180,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="post13.html">
-                                <img src="assets/img/blogpics/Blog13/post13.jpg" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/Blog13/post13.jpg" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -205,7 +205,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="post12.html">
-                                <img src="assets/img/blogpics/blog12/Post12.jpg" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/blog12/Post12.jpg" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -230,7 +230,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="post11.html">
-                                <img src="assets/img/blogpics/post11.1.png" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/post11.1.png" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -255,7 +255,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="Post10.html">
-                                <img src="assets/img/blogpics/Nutree_Thumbnail.png" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/Nutree_Thumbnail.png" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -280,7 +280,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="Post9.html">
-                                <img src="assets/img/blogpics/blog9/Blog9Header.jpg" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/blog9/Blog9Header.jpg" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -306,7 +306,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="post8.html">
-                                <img src="assets/post8/Post8.1.jpg" class="img-res; center" alt=""
+                                <img src="assets/post8/Post8.1.jpg" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -333,7 +333,7 @@
                         <hr style="border-width: 2px; border-color: #6fc754;">
                         <article class="blog-post">
                             <a href="post7.html">
-                                <img src="assets/img/blogpics/post7/post7_header.png" class="img-res; center" alt=""
+                                <img src="assets/img/blogpics/post7/post7_header.png" class="img-res center" alt=""
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -363,7 +363,7 @@
                             <div class="col-md-12">
                                 <article class="blog-post">
                                     <a href="post6.html">
-                                        <img src="assets/img/blogpics/post6/blog6header.JPG" class="img-res; center"
+                                        <img src="assets/img/blogpics/post6/blog6header.JPG" class="img-res center"
                                             alt="" style="max-width: 85%;">
                                     </a>
                                     <div class="post-content">
@@ -399,7 +399,7 @@
                                     <div class="col-md-12">
                                         <article class="blog-post">
                                             <a href="post5.html">
-                                                <img src="assets/img/post5header.jpeg" class="img-res; center" alt=""
+                                                <img src="assets/img/post5header.jpeg" class="img-res center" alt=""
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -435,7 +435,7 @@
                                         <hr style="border-width: 2px; border-color: #6fc754;">
                                         <article class="blog-post">
                                             <a href="post4.html">
-                                                <img src="assets/img/blogpics/Blog4.png" class="img-res; center" alt=""
+                                                <img src="assets/img/blogpics/Blog4.png" class="img-res center" alt=""
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -465,7 +465,7 @@
                                         <hr style="border-width: 2px; border-color: #6fc754;">
                                         <article class="blog-post">
                                             <a href="post3.html">
-                                                <img src="assets/img/blogpics/post3.jpg" class="img-res; center" alt=""
+                                                <img src="assets/img/blogpics/post3.jpg" class="img-res center" alt=""
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -501,7 +501,7 @@
                                         <hr style="border-width: 2px; border-color: #6fc754;">
                                         <article class="blog-post">
                                             <a href="post2.html">
-                                                <img src="assets/img/blogpics/blog2.jpg" class="img-res; center" alt=""
+                                                <img src="assets/img/blogpics/blog2.jpg" class="img-res center" alt=""
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -531,7 +531,7 @@
                                         <hr style="border-width: 2px; border-color: #6fc754;">
                                         <article class="blog-post">
                                             <a href="post1.html">
-                                                <img src="assets/img/blogpics/blog1.jpg" class="img-res; center" alt=""
+                                                <img src="assets/img/blogpics/blog1.jpg" class="img-res center" alt=""
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">


### PR DESCRIPTION
## Summary
- correct misformatted class attribute `img-res; center` to `img-res center` for preview images in blog.html

## Testing
- `curl -I http://localhost:8000/blog.html`
- `curl -I http://localhost:8000/assets/img/blogpics/blog16/blog16.1.jpg`


------
https://chatgpt.com/codex/tasks/task_e_68a71e6da45c83238d7a899281c37a99