### PR TITLE
Add alt text to blog images for accessibility

### DIFF
--- a/Post12.html
+++ b/Post12.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -105,7 +105,7 @@
                     <div class="col-md-12">
                         <article class="blog-post">
                             <img src="assets/img/blogpics/blog12/Post12.jpg" class="img-res"
-                                style="object-fit: scale-down;" alt="">
+                                style="object-fit: scale-down;" alt="NuTree Projektfoto">
                                 <p class="service-info" style="text-align: center; margin-top: 10px; font-size: 80%; font-style: italic; max-width: 80%; margin-left: auto; margin-right: auto;">
                                     vlnr: Manuel Kornmayer (Landeshauptstadt Hannover, Fachbereich Umwelt und Stadtgrün), Thormin Stiegler (Thorkas), Stephan Bonk (Bonk Baumschulen), Greta Fenske (Seedhouse), Jan Pinski (Landeshauptstadt Hannover, Fachbereich Umwelt und Stadtgrün), Lukas Kamm (Agvolution GmbH), Dr. Michael Malms (mm-it4you) 
                                 </p>
@@ -167,7 +167,7 @@
                         <div class="col-md-12 col-xs-12">
                             <div class="service">
                                 <img src="assets/img/blogpics/blog12/post12.4.png"
-                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="">
+                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="NuTree Projektfoto">
                         
                                 <p class="service-info" style="text-align: center; margin-top: 10px; font-size: 80%; font-style: italic; max-width: 80%; margin-left: auto; margin-right: auto;">
                                     vlnr: Manuel Kornmayer (Landeshauptstadt Hannover, Fachbereich Umwelt und Stadtgrün), Thormin Stiegler (Thorkas), Jan Pinski (Landeshauptstadt Hannover, Fachbereich Umwelt und Stadtgrün), Dr. Michael Malms (mm-it4you), Lukas Kamm (Agvolution GmbH), Stephan Bonk (Bonk Baumschulen)
@@ -191,7 +191,7 @@
                     </div>
                     <div class="post-meta">
                         <span class="post-author">
-                            <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="">
+                            <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">
                                 Greta Fenske</a>
                         </span>
                         <span class="post-date">

--- a/Post13.html
+++ b/Post13.html
@@ -53,7 +53,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -104,7 +104,7 @@
                     <div class="col-md-12">
                         <article class="blog-post">
                             <img src="assets/img/blogpics/Blog13/13.jpg" class="img-res"
-                                style="object-fit: scale-down;" alt="">
+                                style="object-fit: scale-down;" alt="NuTree Projektfoto">
                             <p style="margin-top: 5px;"></p> <p style="text-align: center; margin-top: 10px; font-size: 80%; font-style: italic; max-width: 80%; margin-left: auto; margin-right: auto;">
                                 Jan Pinski (Landeshauptstadt Hannover, Bereich Umwelt und Stadtgrün)
                             </p>
@@ -120,7 +120,7 @@
                                 <div class="col-md-12 col-xs-12">
                                     <div class="service">
                                         <img src="assets/img/blogpics/Blog13/13.1.jpg"
-                                            style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="">
+                                            style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="NuTree Projektfoto">
                                         <p class="service-info" style="text-align: center; margin-top: 10px; font-size: 80%; font-style: italic; max-width: 80%; margin-left: auto; margin-right: auto;">
                                             Gesamtansicht einer Neupflanzung in der Innenstadt von Hannover (Quercus cerris)
                                         </p>
@@ -136,13 +136,13 @@
                                         <div class="col-md-6 col-xs-12">
                                             <div class="service">
                                                 <img src="assets/img/blogpics/Blog13/13.2.jpg"
-                                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="">
+                                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="NuTree Projektfoto">
                                             </div>
                                         </div>
                                         <div class="col-md-6 col-xs-12">
                                             <div class="service">
                                                 <img src="assets/img/blogpics/Blog13/13.3.jpg"
-                                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="">
+                                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="NuTree Projektfoto">
                                             </div>
                                         </div>
                                     </div>
@@ -164,7 +164,7 @@
                             </div>
                             <div class="post-meta">
                                 <span class="post-author">
-                                    <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="">
+                                    <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">
                                         Greta Fenske</a>
                                 </span>
                                 <span class="post-date">

--- a/Post14.html
+++ b/Post14.html
@@ -53,7 +53,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -104,7 +104,7 @@
                     <div class="col-md-12">
                         <article class="blog-post">
                             <img src="assets/img/blogpics/blog 14/14.1.jpg" class="img-res"
-                                style="object-fit: scale-down;" alt="">
+                                style="object-fit: scale-down;" alt="NuTree Projektfoto">
                             <p style="margin-top: 5px;"></p>
                             <p
                                 style="text-align: center; margin-top: 10px; font-size: 80%; font-style: italic; max-width: 80%; margin-left: auto; margin-right: auto;">
@@ -128,7 +128,7 @@
                                     <div class="service">
                                         <img src="assets/img/blogpics/blog 14/14.2.jpg"
                                             style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;"
-                                            alt="">
+                                            alt="NuTree Projektfoto">
                                         <p class="service-info"
                                             style="text-align: center; margin-top: 10px; font-size: 80%; font-style: italic; max-width: 80%; margin-left: auto; margin-right: auto;">
                                             Greta Fenske (Seedhouse Accelerator) und (Landeshauptstadt Hannover, Bereich
@@ -170,7 +170,7 @@
                             </div>
                             <div class="post-meta">
                                 <span class="post-author">
-                                    <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="">
+                                    <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">
                                         Greta Fenske</a>
                                 </span>
                                 <span class="post-date">

--- a/Post15.html
+++ b/Post15.html
@@ -49,7 +49,7 @@
         <nav id="primary-navigation" class="site-navigation">
             <div class="container">
                 <div class="navbar-header">
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
                 </div>
                 <div class="collapse navbar-collapse" id="agency-navbar-collapse">
                     <ul class="nav navbar-nav navbar-right">
@@ -221,7 +221,7 @@
                             </div>
                             <div class="post-meta">
                                 <span class="post-author">
-                                    <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Author Image">
+                                    <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">
                                         Greta Fenske</a>
                                 </span>
                                 <span class="post-date">

--- a/Post16.html
+++ b/Post16.html
@@ -49,7 +49,7 @@
         <nav id="primary-navigation" class="site-navigation">
             <div class="container">
                 <div class="navbar-header">
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
                 </div>
                 <div class="collapse navbar-collapse" id="agency-navbar-collapse">
                     <ul class="nav navbar-nav navbar-right">
@@ -144,13 +144,13 @@
                                         <div class="col-md-6 col-xs-12">
                                             <div class="service">
                                                 <img src="assets/img/blogpics/blog16/blog16.2.1.jpg"
-                                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="">
+                                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="NuTree Projektfoto">
                                             </div>
                                         </div>
                                         <div class="col-md-6 col-xs-12">
                                             <div class="service">
                                                 <img src="assets/img/blogpics/blog16/Blog16.2.2.jpg"
-                                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="">
+                                                    style="object-fit: contain; width: 100%; max-height: 600px; margin: 0 auto;" alt="NuTree Projektfoto">
                                             </div>
                                         </div>
                                     </div>
@@ -183,7 +183,7 @@
                             <div class="post-meta">
                                 <span class="post-author">
                                     <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                            alt="Author Image">
+                                            alt="Porträt von Greta Fenske">
                                         Greta Fenske</a>
                                 </span>
                                 <span class="post-date">

--- a/Post9.html
+++ b/Post9.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -105,7 +105,7 @@
                     <div class="col-md-12">
                         <article class="blog-post">
                             <img src="assets/img/blogpics/blog9/Blog9Header.jpg" class="img-res"
-                                style="object-fit: scale-down;" alt="">
+                                style="object-fit: scale-down;" alt="NuTree Projektfoto">
                             <p style="margin-top: 5px;"></p>
                             <div class="post-content">
                                 <h1 class="post-title">Erster Baumtransport mit Sensor - von Bad Zwischenahn nach
@@ -130,7 +130,7 @@
                                 <div class="col-md-4 col-xs-6">
                                     <div class="service">
                                         <img src="assets/img/blogpics/blog9/Blog91.1.jpg"
-                                            style="object-fit: scale-down; max-height: 400px;" alt="">
+                                            style="object-fit: scale-down; max-height: 400px;" alt="NuTree Projektfoto">
 
                                         <p class="service-info"> </p>
                                     </div><!-- /.service -->
@@ -138,7 +138,7 @@
                                 <div class="col-md-8 col-xs-6">
                                     <div class="service">
                                         <img src="assets/img/blogpics/blog9/Blog91.2.jpg"
-                                            style="object-fit: scale-down; max-height: 400px;" alt="">
+                                            style="object-fit: scale-down; max-height: 400px;" alt="NuTree Projektfoto">
 
                                         <p class="service-info"> </p>
                                     </div><!-- /.service -->
@@ -149,7 +149,7 @@
                                 <div class="col-md-6 col-xs-6">
                                     <div class="service">
                                         <img src="assets/img/blogpics/blog9/Blog92.1.jpg"
-                                            style="object-fit: scale-down; max-height: 400px;" alt="">
+                                            style="object-fit: scale-down; max-height: 400px;" alt="NuTree Projektfoto">
 
                                         <p class="service-info"> </p>
                                     </div><!-- /.service -->
@@ -157,7 +157,7 @@
                                 <div class="col-md-6 col-xs-6">
                                     <div class="service">
                                         <img src="assets/img/blogpics/blog9/Blog92.2.jpg"
-                                            style="object-fit: scale-down; max-height: 400px;" alt="">
+                                            style="object-fit: scale-down; max-height: 400px;" alt="NuTree Projektfoto">
 
                                         <p class="service-info"> </p>
                                     </div><!-- /.service -->
@@ -165,7 +165,7 @@
                                 <div class="col-md-12 col-xs-12">
                                     <div class="service">
                                         <img src="assets/img/blogpics/blog9/Blog9.3.2.jpg"
-                                            style="object-fit: scale-down;" alt="">
+                                            style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                         <p class="service-info"></p>
                                     </div><!-- /.service -->
@@ -188,7 +188,7 @@
                         <div class="col-md-12 col-xs-12">
                             <div class="service">
                                 <img src="assets/img/blogpics/blog9/Lieferung_Tracking3.png"
-                                    style="object-fit: scale-down; max-height: 600px;" alt="">
+                                    style="object-fit: scale-down; max-height: 600px;" alt="NuTree Projektfoto">
 
                                 <p class="service-info"></p>
                             </div><!-- /.service -->
@@ -210,7 +210,7 @@
                         <div class="col-md-4 col-xs-12">
                             <div class="service">
                                 <img src="assets/img/blogpics/blog9/Blog94.1.JPG"
-                                    style="object-fit: scale-down; max-height: 400px;" alt="">
+                                    style="object-fit: scale-down; max-height: 400px;" alt="NuTree Projektfoto">
 
                                 <p class="service-info"></p>
                             </div><!-- /.service -->
@@ -220,7 +220,7 @@
                         <div class="col-md-4 col-xs-12">
                             <div class="service">
                                 <img src="assets/img/blogpics/blog9/Blog94.2.JPG"
-                                    style="object-fit: scale-down; max-height: 400px;" alt="">
+                                    style="object-fit: scale-down; max-height: 400px;" alt="NuTree Projektfoto">
 
                                 <p class="service-info"></p>
                             </div><!-- /.service -->
@@ -230,7 +230,7 @@
                         <div class="col-md-4 col-xs-12">
                             <div class="service">
                                 <img src="assets/img/blogpics/blog9/Blog94.3.JPG"
-                                    style="object-fit: scale-down; max-height: 400px;" alt="">
+                                    style="object-fit: scale-down; max-height: 400px;" alt="NuTree Projektfoto">
 
                                 <p class="service-info"></p>
                             </div><!-- /.service -->
@@ -255,7 +255,7 @@
                     </div>
                     <div class="post-meta">
                         <span class="post-author">
-                            <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="">
+                            <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">
                                 Greta Fenske</a>
                         </span>
                         <span class="post-date">

--- a/blog.html
+++ b/blog.html
@@ -53,7 +53,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" href="index.html" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" href="index.html" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -103,7 +103,7 @@
                     <div class="col-md-12">
                         <article class="blog-post">
                             <a href="Post16.html">
-                                <img src="assets/img/blogpics/blog16/blog16.1.jpg" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/blog16/blog16.1.jpg" class="img-res center" alt="Titelbild: NuTree Workshop auf den Baumpflegetagen"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -118,7 +118,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>November 2024</a>
@@ -128,7 +128,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="Post15.html">
-                                <img src="assets/img/blogpics/Post15/15.1.jpg" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/Post15/15.1.jpg" class="img-res center" alt="Titelbild: Versuchsflächen in der Baumschule Bonk"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -144,7 +144,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>Oktober 2024</a>
@@ -154,7 +154,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="Post14.html">
-                                <img src="assets/img/blogpics/blog 14/14.1.jpg" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/blog 14/14.1.jpg" class="img-res center" alt="Titelbild: EIP-Sommerfest mit Ministerin Miriam Staudte"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -170,7 +170,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>September 2024</a>
@@ -180,7 +180,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="post13.html">
-                                <img src="assets/img/blogpics/Blog13/post13.jpg" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/Blog13/post13.jpg" class="img-res center" alt="Titelbild: Sensorinstallation in Hannover"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -195,7 +195,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>Juni 2024</a>
@@ -205,7 +205,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="post12.html">
-                                <img src="assets/img/blogpics/blog12/Post12.jpg" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/blog12/Post12.jpg" class="img-res center" alt="Titelbild: NuTree Projekttreffen 20.02.2024"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -220,7 +220,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>Mai 2024</a>
@@ -230,7 +230,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="post11.html">
-                                <img src="assets/img/blogpics/post11.1.png" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/post11.1.png" class="img-res center" alt="Titelbild: Artikel zum Baumtransport"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -245,7 +245,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>April 2024</a>
@@ -255,7 +255,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="Post10.html">
-                                <img src="assets/img/blogpics/Nutree_Thumbnail.png" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/Nutree_Thumbnail.png" class="img-res center" alt="Titelbild: NuTree Projekt Video"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -270,7 +270,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>Februar 2023</a>
@@ -280,7 +280,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="Post9.html">
-                                <img src="assets/img/blogpics/blog9/Blog9Header.jpg" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/blog9/Blog9Header.jpg" class="img-res center" alt="Titelbild: Erster Baumtransport mit Sensor"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -296,7 +296,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>Dezember 2023</a>
@@ -306,7 +306,7 @@
                         </article><!-- /.blog-post -->
                         <article class="blog-post">
                             <a href="post8.html">
-                                <img src="assets/post8/Post8.1.jpg" class="img-res center" alt=""
+                                <img src="assets/post8/Post8.1.jpg" class="img-res center" alt="Titelbild: NuTree auf Tour"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -322,7 +322,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>Oktober 2023</a>
@@ -333,7 +333,7 @@
                         <hr style="border-width: 2px; border-color: #6fc754;">
                         <article class="blog-post">
                             <a href="post7.html">
-                                <img src="assets/img/blogpics/post7/post7_header.png" class="img-res center" alt=""
+                                <img src="assets/img/blogpics/post7/post7_header.png" class="img-res center" alt="Titelbild: Artikel in Deutsche Baumschule"
                                     style="max-width: 85%;">
                             </a>
                             <div class="post-content">
@@ -349,7 +349,7 @@
                                 <div class="post-meta">
                                     <span class="post-author">
                                         <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                alt="">Greta Fenske</a>
+                                                alt="Porträt von Greta Fenske">Greta Fenske</a>
                                     </span>
                                     <span class="post-date">
                                         <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>Juni 2023</a>
@@ -364,7 +364,7 @@
                                 <article class="blog-post">
                                     <a href="post6.html">
                                         <img src="assets/img/blogpics/post6/blog6header.JPG" class="img-res center"
-                                            alt="" style="max-width: 85%;">
+                                            alt="Titelbild: Start der neuen Versuchsphase" style="max-width: 85%;">
                                     </a>
                                     <div class="post-content">
                                         <h3 class="post-title"><a href="post6.html">Start der neuen Versuchsphase in
@@ -386,7 +386,7 @@
                                         <div class="post-meta">
                                             <span class="post-author">
                                                 <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                        alt="">Greta Fenske</a>
+                                                        alt="Porträt von Greta Fenske">Greta Fenske</a>
                                             </span>
                                             <span class="post-date">
                                                 <a href=""><i class="fa fa-calendar" aria-hidden="true"></i>Mai 2023</a>
@@ -399,7 +399,7 @@
                                     <div class="col-md-12">
                                         <article class="blog-post">
                                             <a href="post5.html">
-                                                <img src="assets/img/post5header.jpeg" class="img-res center" alt=""
+                                                <img src="assets/img/post5header.jpeg" class="img-res center" alt="Titelbild: Halbjahresmeeting in Baumschule Bonk"
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -421,7 +421,7 @@
                                                 <div class="post-meta">
                                                     <span class="post-author">
                                                         <a href="#"><img class="img-res"
-                                                                src="assets/img/blogpics/Greta4.png" alt="">Greta
+                                                                src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">Greta
                                                             Fenske</a>
                                                     </span>
                                                     <span class="post-date">
@@ -435,7 +435,7 @@
                                         <hr style="border-width: 2px; border-color: #6fc754;">
                                         <article class="blog-post">
                                             <a href="post4.html">
-                                                <img src="assets/img/blogpics/Blog4.png" class="img-res center" alt=""
+                                                <img src="assets/img/blogpics/Blog4.png" class="img-res center" alt="Titelbild: NuTree im Wirtschaftsmagazin"
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -452,7 +452,7 @@
                                                 <div class="post-meta">
                                                     <span class="post-author">
                                                         <a href="#"><img class="img-res"
-                                                                src="assets/img/blogpics/Greta4.png" alt="">Greta
+                                                                src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">Greta
                                                             Fenske</a>
                                                     </span>
                                                     <span class="post-date">
@@ -465,7 +465,7 @@
                                         <hr style="border-width: 2px; border-color: #6fc754;">
                                         <article class="blog-post">
                                             <a href="post3.html">
-                                                <img src="assets/img/blogpics/post3.jpg" class="img-res center" alt=""
+                                                <img src="assets/img/blogpics/post3.jpg" class="img-res center" alt="Titelbild: NuTree auf dem Titelblatt"
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -488,7 +488,7 @@
                                                 <div class="post-meta">
                                                     <span class="post-author">
                                                         <a href="#"><img class="img-res"
-                                                                src="assets/img/blogpics/Greta4.png" alt="">Greta
+                                                                src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">Greta
                                                             Fenske</a>
                                                     </span>
                                                     <span class="post-date">
@@ -501,7 +501,7 @@
                                         <hr style="border-width: 2px; border-color: #6fc754;">
                                         <article class="blog-post">
                                             <a href="post2.html">
-                                                <img src="assets/img/blogpics/blog2.jpg" class="img-res center" alt=""
+                                                <img src="assets/img/blogpics/blog2.jpg" class="img-res center" alt="Titelbild: Erstes Projekttreffen Baumschule Bonk"
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -518,7 +518,7 @@
                                                 <div class="post-meta">
                                                     <span class="post-author">
                                                         <a href="#"><img class="img-res"
-                                                                src="assets/img/blogpics/Greta4.png" alt="">Greta
+                                                                src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">Greta
                                                             Fenske</a>
                                                     </span>
                                                     <span class="post-date">
@@ -531,7 +531,7 @@
                                         <hr style="border-width: 2px; border-color: #6fc754;">
                                         <article class="blog-post">
                                             <a href="post1.html">
-                                                <img src="assets/img/blogpics/blog1.jpg" class="img-res center" alt=""
+                                                <img src="assets/img/blogpics/blog1.jpg" class="img-res center" alt="Titelbild: Auftaktveranstaltung des 5. EIP Calls"
                                                     style="max-width: 85%;">
                                             </a>
                                             <div class="post-content">
@@ -552,7 +552,7 @@
                                                 <div class="post-meta">
                                                     <span class="post-author">
                                                         <a href="#"><img class="img-res"
-                                                                src="assets/img/blogpics/Greta4.png" alt="">Greta Fenske
+                                                                src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">Greta Fenske
                                                         </a>
                                                     </span>
                                                     <span class="post-date">

--- a/post1.html
+++ b/post1.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -104,7 +104,7 @@
                 <div class="row">
                     <div class="col-md-12">
                         <article class="blog-post">
-                            <img src="assets/img/blogpics/blog1.jpg" class="img-res" alt="">
+                            <img src="assets/img/blogpics/blog1.jpg" class="img-res" alt="NuTree Projektfoto">
                             <p>Quelle: Niedersächsisches Ministerium für Ernährung, Landwirtschaft und Verbraucherschutz
                             </p>
                             <div class="post-content">
@@ -126,7 +126,7 @@
                                 </div>
                                 <div class="post-meta">
                                     <span class="post-author">
-                                        <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="">
+                                        <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">
                                             Greta Fenske</a>
                                     </span>
                                     <span class="post-date">

--- a/post11.html
+++ b/post11.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -125,7 +125,7 @@
                                         <div class="post-meta">
                                             <span class="post-author">
                                                 <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                        alt="">
+                                                        alt="Porträt von Greta Fenske">
                                                     Greta Fenske</a>
                                             </span>
                                             <span class="post-date">

--- a/post2.html
+++ b/post2.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -104,7 +104,7 @@
                 <div class="row">
                     <div class="col-md-12">
                         <article class="blog-post">
-                            <img src="assets/img/blogpics/blog2.jpg" class="img-res" alt=""
+                            <img src="assets/img/blogpics/blog2.jpg" class="img-res" alt="NuTree Projektfoto"
                                 style="object-fit: scale-down;">
                             <p>v.l.n.r. Andreas Heckmann (Agvolution), Greta Fenske (Seedhouse Accelerator), Dr. Michael
                                 Malms (mm-it4you), Stephan Bonk (Bonk Baumschulen), Manuel Kornmayer und Tina Kruse
@@ -124,7 +124,7 @@
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
                                             <img src="assets/img/blogpics/post2/post21.jpg"
-                                                style="object-fit: scale-down;" alt="">
+                                                style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -132,7 +132,7 @@
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
                                             <img src="assets/img/blogpics/post2/post22.jpg"
-                                                style="object-fit: scale-down;" alt="">
+                                                style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -140,7 +140,7 @@
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
                                             <img src="assets/img/blogpics/post2/post23.jpg"
-                                                style="object-fit: scale-down;" alt="">
+                                                style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"></p>
                                         </div><!-- /.service -->
@@ -149,7 +149,7 @@
                                         <div class="col-md-4 col-xs-6">
                                             <div class="service">
                                                 <img src="assets/img/blogpics/post2/post24.jpg"
-                                                    style="object-fit: scale-down;" alt="">
+                                                    style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                                 <p class="service-info"> </p>
                                             </div><!-- /.service -->
@@ -157,7 +157,7 @@
                                         <div class="col-md-4 col-xs-6">
                                             <div class="service">
                                                 <img src="assets/img/blogpics/post2/post25.jpg"
-                                                    style="object-fit: scale-down;" alt="">
+                                                    style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                                 <p class="service-info"> </p>
                                             </div><!-- /.service -->
@@ -165,7 +165,7 @@
                                         <div class="col-md-4 col-xs-6">
                                             <div class="service">
                                                 <img src="assets/img/blogpics/post2/post26.jpg"
-                                                    style="object-fit: scale-down;" alt="">
+                                                    style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                                 <p class="service-info"></p>
                                             </div><!-- /.service -->
@@ -184,7 +184,7 @@
                                             statt, auch in Zukunft soll eine enge Abstimmung zwischen beiden OG´s
                                             erfolgen.</p><br /><br />
 
-                                        <img src="assets/img/blogpics/post30.jpg" class="img-res" alt=""
+                                        <img src="assets/img/blogpics/post30.jpg" class="img-res" alt="NuTree Projektfoto"
                                             style="object-fit: scale-down;">
                                         <p style="font-size: 14px; font-weight: 300; color: #9fa3a7; line-height: 22px;">v.l.n.r. Stephan und Sebastian Bonk (Bonk Baumschulen), Dr. Michael Malms
                                             (mm-it4you), Greta Fenske (Seedhouse Accelerator), Heinrich Beltz (LWK
@@ -200,7 +200,7 @@
                                         <div class="post-meta">
                                             <span class="post-author">
                                                 <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                        alt="">
+                                                        alt="Porträt von Greta Fenske">
                                                     Greta Fenske</a>
                                             </span>
                                             <span class="post-date">

--- a/post3.html
+++ b/post3.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -104,7 +104,7 @@
                 <div class="row">
                     <div class="col-md-12">
                         <article class="blog-post">
-                            <img src="assets/img/blogpics/post3.jpg" class="img-res" alt=""
+                            <img src="assets/img/blogpics/post3.jpg" class="img-res" alt="NuTree Projektfoto"
                                 style="object-fit: scale-down;">
                             <p>Das Magazin für deutsche Baumschulen</p>
                             <div class="post-content">
@@ -129,7 +129,7 @@
                                         <div class="post-meta">
                                             <span class="post-author">
                                                 <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                        alt="">
+                                                        alt="Porträt von Greta Fenske">
                                                     Greta Fenske</a>
                                             </span>
                                             <span class="post-date">

--- a/post4.html
+++ b/post4.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -125,7 +125,7 @@
                                         <div class="post-meta">
                                             <span class="post-author">
                                                 <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                        alt="">
+                                                        alt="Porträt von Greta Fenske">
                                                     Greta Fenske</a>
                                             </span>
                                             <span class="post-date">

--- a/post5.html
+++ b/post5.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -105,7 +105,7 @@
                     <div class="col-md-12">
                         <article class="blog-post">
                             <img src="assets/img/post5header.jpeg" class="img-res" style="object-fit: scale-down;"
-                                alt="">
+                                alt="NuTree Projektfoto">
                             <p style="margin-top: 5px;">Andreas Heckmann (Agvolution GmbH) im Gespräch mit Dr. Michael Malms (mm-it4you)</p>
                             <div class="post-content">
                                 <h1 class="post-title">Halbjahresmeeting in der Baumschule Bonk</h1>
@@ -126,21 +126,21 @@
                                 <div>
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
-                                            <img src="assets/img/post5.1.jpeg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/post5.1.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
                                     </div>
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
-                                            <img src="assets/img/post5.2.jpeg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/post5.2.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
                                     </div>
                                     <div class="col-md-4 col-xs-12">
                                         <div class="service">
-                                            <img src="assets/img/post5.3.jpeg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/post5.3.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"></p>
                                         </div><!-- /.service -->
@@ -164,21 +164,21 @@
                             <div class="row">
                                 <div class="col-md-4 col-xs-6">
                                     <div class="service">
-                                        <img src="assets/img/Post5.4.jpeg" style="object-fit: scale-down;" alt="">
+                                        <img src="assets/img/Post5.4.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                         <p class="service-info"> </p>
                                     </div><!-- /.service -->
                                 </div>
                                 <div class="col-md-4 col-xs-6">
                                     <div class="service">
-                                        <img src="assets/img/Post5.5.jpeg" style="object-fit: scale-down;" alt="">
+                                        <img src="assets/img/Post5.5.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                         <p class="service-info"> </p>
                                     </div><!-- /.service -->
                                 </div>
                                 <div class="col-md-4 col-xs-12">
                                     <div class="service">
-                                        <img src="assets/img/Post5.6.jpeg" style="object-fit: scale-down;" alt="">
+                                        <img src="assets/img/Post5.6.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                         <p class="service-info"></p>
                                     </div><!-- /.service -->
@@ -230,7 +230,7 @@
                                 </div>
                             </div>
                                     <img src="assets/img/post5team.jpeg" class="img-res"
-                                        style="object-fit: scale-down; margin-top: 20px;" alt="">
+                                        style="object-fit: scale-down; margin-top: 20px;" alt="NuTree Projektfoto">
                                     <br style="margin-top: 5px;">v.l.n.r. Jan Pinski und Tina Kruse (Landeshauptstadt
                                         Hannover, Bereich Umwelt und Stadtgrün), </br>Greta Fenske (Seedhouse Accelerator),
                                         Stephan Bonk (Bonk Baumschulen), Dr. Michael Malms (mm-it4you), </br>Andreas Heckmann
@@ -241,7 +241,7 @@
                                     <div class="post-meta">
                                         <span class="post-author">
                                             <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                    alt="">
+                                                    alt="Porträt von Greta Fenske">
                                                 Greta Fenske</a>
                                         </span>
                                         <span class="post-date">

--- a/post6.html
+++ b/post6.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -105,7 +105,7 @@
                     <div class="col-md-12">
                         <article class="blog-post">
                             <img src="assets/img/blogpics/post6/blog6header.JPG" class="img-res" style="object-fit: scale-down;"
-                                alt="">
+                                alt="NuTree Projektfoto">
                             <p style="margin-top: 5px;"></p>
                             <div class="post-content">
                                 <h1 class="post-title">Start der neuen Versuchsphase in <br>Hannover und Bad Zwischenahn
@@ -123,21 +123,21 @@
                                 <div>
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.1.1.JPG" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.1.1.JPG" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
                                     </div>
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.1.2.JPG" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.1.2.JPG" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
                                     </div>
                                     <div class="col-md-4 col-xs-12">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.1.3.JPG" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.1.3.JPG" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"></p>
                                         </div><!-- /.service -->
@@ -146,21 +146,21 @@
                                 <div>
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.2.1.JPG" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.2.1.JPG" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
                                     </div>
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.2.2.JPG" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.2.2.JPG" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
                                     </div>
                                     <div class="col-md-4 col-xs-12">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.2.3.JPG" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.2.3.JPG" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"></p>
                                         </div><!-- /.service -->
@@ -187,21 +187,21 @@
                                 <div>
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.3.1.jpeg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.3.1.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
                                     </div>
                                     <div class="col-md-4 col-xs-6">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.3.2.jpeg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.3.2.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
                                     </div>
                                     <div class="col-md-4 col-xs-12">
                                         <div class="service">
-                                            <img src="assets/img/blogpics/post6/blog6.3.3.jpeg" style="object-fit: scale-down; width: 360px;" alt="">
+                                            <img src="assets/img/blogpics/post6/blog6.3.3.jpeg" style="object-fit: scale-down; width: 360px;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"></p>
                                         </div><!-- /.service -->
@@ -227,7 +227,7 @@
                                 </div>
                                 <div class="post-meta">
                                     <span class="post-author">
-                                        <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="">
+                                        <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">
                                             Greta Fenske</a>
                                     </span>
                                     <span class="post-date">

--- a/post7.html
+++ b/post7.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -125,7 +125,7 @@
                                         <div class="post-meta">
                                             <span class="post-author">
                                                 <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png"
-                                                        alt="">
+                                                        alt="Porträt von Greta Fenske">
                                                     Greta Fenske</a>
                                             </span>
                                             <span class="post-date">

--- a/post8.html
+++ b/post8.html
@@ -54,7 +54,7 @@
 
                 <div class="navbar-header">
 
-                    <img src="assets/img/pics/Logo_mini.png" alt="">
+                    <img src="assets/img/pics/Logo_mini.png" alt="NuTree Logo">
 
                 </div><!-- /.navbar-header -->
 
@@ -104,7 +104,7 @@
                 <div class="row">
                     <div class="col-md-12">
                         <article class="blog-post">
-                            <img src="assets/post8/Post8.1.jpg" class="img-res" style="object-fit: scale-down;" alt="">
+                            <img src="assets/post8/Post8.1.jpg" class="img-res" style="object-fit: scale-down;" alt="NuTree Projektfoto">
                             <p style="margin-top: 5px;">Andreas Heckmann (Agvolution GmbH), Greta Fenske (Seedhouse
                                 Accelerator), Jan Pinski (Stadt Hannover)</p>
                             <div class="post-content">
@@ -121,7 +121,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.2.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.2.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -133,7 +133,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.3.1.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.3.1.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -141,7 +141,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.3.2.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.3.2.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -152,7 +152,7 @@
                                     <h3>12.08.2023: Baumschultag der Landwirtschaftskammer Niedersachsen in Bad Zwischenahn</h3>
                                     <div class="col-md-12 col-xs-12">         
                                         <div class="service">
-                                            <img src="assets/post8/Post8.4.1.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.4.1.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -160,7 +160,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.4.2.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.4.2.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -168,7 +168,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.4.3.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.4.3.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -180,7 +180,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.1.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.1.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -192,7 +192,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.6.1.jpeg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.6.1.jpeg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -204,7 +204,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.7.1.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.7.1.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -212,7 +212,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.7.2.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.7.2.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -220,7 +220,7 @@
                                     <div class="col-md-12 col-xs-12">
                                       
                                         <div class="service">
-                                            <img src="assets/post8/Post8.7.3.jpg" style="object-fit: scale-down;" alt="">
+                                            <img src="assets/post8/Post8.7.3.jpg" style="object-fit: scale-down;" alt="NuTree Projektfoto">
 
                                             <p class="service-info"> </p>
                                         </div><!-- /.service -->
@@ -235,7 +235,7 @@
                                 </div>
                                 <div class="post-meta">
                                     <span class="post-author">
-                                        <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="">
+                                        <a href="#"><img class="img-res" src="assets/img/blogpics/Greta4.png" alt="Porträt von Greta Fenske">
                                             Greta Fenske</a>
                                     </span>
                                     <span class="post-date">


### PR DESCRIPTION
## Summary
- add descriptive alt text to blog index previews and author images
- provide alt text placeholders for blog post images to support screen readers

## Testing
- `npx --yes pa11y blog.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a735b8c14c832393500eee0a561cd9